### PR TITLE
Up to fixed filesize-parser version 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "filesize-parser": "~1.1.0",
+    "filesize-parser": "~1.2.0",
     "node-expat": "2.3.x",
     "q": "^1.1.1"
   }


### PR DESCRIPTION
"Bytes doesn't appear to be a valid unit" with filesize-parser 1.1.0, fixed in 1.2.0 [at this commit](https://github.com/patrickkettner/filesize-parser/pull/5)
